### PR TITLE
chore: remove work-around for missing user in mlmd image

### DIFF
--- a/.github/workflows/build-image-pr.yml
+++ b/.github/workflows/build-image-pr.yml
@@ -56,16 +56,6 @@ jobs:
         run: |
           kubectl apply -k config/samples/postgres/
           kubectl describe mr
-      - name: Patch Test Registry Deployment for Kind SecurityContext missing userid in mlmd
-        run: |
-          kubectl wait --for=condition=Progressing=True deployment/modelregistry-sample --timeout=5m
-          # patch mlmd container for Kind
-          kubectl patch deployment/modelregistry-sample --type='json' \
-            -p='[{"op":"add","path":"/spec/template/spec/containers/0/securityContext/runAsUser","value":1000860000}]' \
-            || (kubectl describe deployment/modelregistry-sample; exit 1)
-          kubectl patch deployment/modelregistry-sample --type='json' \
-            -p='[{"op":"add","path":"/spec/template/spec/containers/0/securityContext/runAsGroup","value":1000860000}]' \
-            || (kubectl describe deployment/modelregistry-sample; exit 1)
       - name: Wait for Test Registry Deployment
         run: |
           ##debug


### PR DESCRIPTION
## Description

Remove the work-around to patch the `runAsUser` and `runAsGroup` in the kind test.

## How Has This Been Tested?


## Merge criteria:

- [x] The commits and have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
